### PR TITLE
chore(circle): automate releases with semantic release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,6 @@ jobs:
             git config --global user.name "aumitleon"
             . venv/bin/activate
             semantic-release publish
-            twine upload dist/*
 
 workflows:
   version: 2


### PR DESCRIPTION
This pull request will resolve #7. `semantic-release` will handle publishing to PyPi and generate automatic releases on merges to master. 