### PR TITLE
chore(test-mkdocs): test if mkdcoks config needs to be in the root

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -5,3 +5,5 @@ extra_javascript: [readthedocs-data.js, 'https://media.readthedocs.org/static/co
 google_analytics: null
 site_name: module_starter_cli
 theme_dir: /home/docs/checkouts/readthedocs.org/readthedocs/templates/mkdocs/readthedocs
+nav:
+- Home: 'index.md'


### PR DESCRIPTION
The purpose of this PR is to test whether or not `mkdocs` actually requires `mkdocs.yml` to live in the root of the repo. 