### PR TITLE
chore(circle): fix caching for circle builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:2.7
     steps:
       - checkout
 


### PR DESCRIPTION
This should resolve #6. 

The issue was that the docker image being cached in the `build` step references a the `python 2.7` docker image, while the `deploy` step references the `python 3.6` image :
https://github.com/AumitLeon/module_starter_cli/blob/a8b2e5caab349c0360e08a075d239f1f1146fa6c/.circleci/config.yml#L4-L5

https://github.com/AumitLeon/module_starter_cli/blob/a8b2e5caab349c0360e08a075d239f1f1146fa6c/.circleci/config.yml#L32-L33

